### PR TITLE
Update bootstrap tarball extension

### DIFF
--- a/arch4vps.amd64.efi.sh
+++ b/arch4vps.amd64.efi.sh
@@ -103,7 +103,7 @@ prtln "" && prtln "..."
 
 prtln "..."
 # Download bootstrap file and extract
-BOOTSTRAP="archlinux-bootstrap-x86_64.tar.gz"
+BOOTSTRAP="archlinux-bootstrap-x86_64.tar.zst"
 curl -fsSL --url "${MIRROR}/iso/latest/${BOOTSTRAP}" -o "${BOOTSTRAP}"
 
 arch_rootfs="archlinux-bootstrap-rootfs"

--- a/arch4vps.amd64.sh
+++ b/arch4vps.amd64.sh
@@ -95,7 +95,7 @@ prtln "" && prtln "..."
 
 prtln "..."
 # Download bootstrap file and extract
-BOOTSTRAP="archlinux-bootstrap-x86_64.tar.gz"
+BOOTSTRAP="archlinux-bootstrap-x86_64.tar.zst"
 curl -fsSL --url "${MIRROR}/iso/latest/${BOOTSTRAP}" -o "${BOOTSTRAP}"
 
 arch_rootfs="archlinux-bootstrap-rootfs"


### PR DESCRIPTION
Starting with the 2024.05.01 release, the Arch Linux bootstrap tarball uses zstd compression.

Related to https://gitlab.archlinux.org/archlinux/archiso/-/issues/130